### PR TITLE
Fix TypeScript errors in Calendar and ThemeController components

### DIFF
--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -1,18 +1,22 @@
 import { clsx } from 'clsx'
+import { forwardRef } from 'react'
 import type { DayPickerProps } from 'react-day-picker'
 import { DayPicker } from 'react-day-picker'
 
-export interface CalendarProps extends DayPickerProps {
+export type CalendarProps = DayPickerProps & {
   className?: string
-  ref?: React.Ref<HTMLDivElement>
 }
 
-export function Calendar({ className, ref, ...props }: CalendarProps) {
-  const classes = clsx('react-day-picker', className)
+export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
+  ({ className, ...props }, ref) => {
+    const classes = clsx('react-day-picker', className)
 
-  return (
-    <div ref={ref}>
-      <DayPicker className={classes} {...props} />
-    </div>
-  )
-}
+    return (
+      <div ref={ref}>
+        <DayPicker className={classes} {...props} />
+      </div>
+    )
+  },
+)
+
+Calendar.displayName = 'Calendar'

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ export type { TextareaProps } from './textarea'
 export { Textarea } from './textarea'
 export type {
   ThemeControllerProps,
-  ThemeControllerStyle,
+  ThemeControllerVariant,
 } from './theme-controller'
 export { ThemeController } from './theme-controller'
 export type {

--- a/src/theme-controller/index.ts
+++ b/src/theme-controller/index.ts
@@ -1,5 +1,5 @@
 export type {
   ThemeControllerProps,
-  ThemeControllerStyle,
+  ThemeControllerVariant,
 } from './theme-controller'
 export { ThemeController } from './theme-controller'

--- a/src/theme-controller/theme-controller.tsx
+++ b/src/theme-controller/theme-controller.tsx
@@ -2,21 +2,21 @@ import { clsx } from 'clsx'
 import type { InputHTMLAttributes } from 'react'
 import { forwardRef } from 'react'
 
-export type ThemeControllerStyle = 'checkbox' | 'toggle' | 'swap'
+export type ThemeControllerVariant = 'checkbox' | 'toggle' | 'swap'
 
 export interface ThemeControllerProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   theme: string
-  style?: ThemeControllerStyle
+  variant?: ThemeControllerVariant
 }
 
 export const ThemeController = forwardRef<HTMLInputElement, ThemeControllerProps>(
-  ({ className, theme, style = 'checkbox', ...props }, ref) => {
+  ({ className, theme, variant = 'checkbox', ...props }, ref) => {
     const classes = clsx(
       'theme-controller',
       {
-        checkbox: style === 'checkbox',
-        toggle: style === 'toggle',
-        swap: style === 'swap',
+        checkbox: variant === 'checkbox',
+        toggle: variant === 'toggle',
+        swap: variant === 'swap',
       },
       className,
     )


### PR DESCRIPTION
- Changed CalendarProps from interface to type with intersection to properly extend DayPickerProps
- Added forwardRef support to Calendar component for proper ref handling
- Renamed ThemeControllerStyle to ThemeControllerVariant to avoid conflict with HTML style attribute
- Updated all exports to use new ThemeControllerVariant type name

All TypeScript checks now pass successfully.